### PR TITLE
Added possibillity to set env variables in test.

### DIFF
--- a/PythonPackage.cmake
+++ b/PythonPackage.cmake
@@ -792,6 +792,10 @@ function(add_python_test TESTNAME PYTHON_TEST_FILE)
     add_test(NAME ${TESTNAME}
             COMMAND ${PYTHON_EXECUTABLE} -m unittest discover -vs ${dir} -p ${name}
             )
+
+    if (ARGC EQUAL 3)
+        set_tests_properties(${TESTNAME} PROPERTIES ENVIRONMENT "${ARGV2}")
+    endif()    
 endfunction()
 
 function(add_python_example pkg TESTNAME PYTHON_TEST_FILE)


### PR DESCRIPTION
The purpose of this is to be able to do:

```
add_python_test( my_test test/my_test_module.py "ENV_VAR1=value1;ENV_VAR2=value2")
```
